### PR TITLE
Update `ModeMap_PolyFit.py` to be compatible with current versions of `matplotlib`

### DIFF
--- a/ModeMap_PolyFit.py
+++ b/ModeMap_PolyFit.py
@@ -13,7 +13,7 @@ import numpy as np;
 import matplotlib as mpl;
 import matplotlib.pyplot as plt;
 
-from mpl_toolkits.axes_grid.anchored_artists import AnchoredText;
+from matplotlib.offsetbox import AnchoredText;
 
 from scipy.optimize import curve_fit;
 


### PR DESCRIPTION
Hi! Thanks for creating such a useful package!
The current code `ModeMap` scripts all work with python 3, with current versions of `matplotlib`/`numpy` etc, except for `ModeMap_PolyFit.py` due to a failed import:

![image](https://github.com/JMSkelton/ModeMap/assets/51478689/2db9ce80-5d69-4e28-a73b-ef1d70fd69ae)

`AnchoredText` has been moved in `matplotlib`, so updating as in this PR fixes this issue.